### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 A Model Context Protocol server that provides browser automation capabilities using BrowserCat's cloud browser service. This server enables LLMs to interact with web pages, take screenshots, and execute JavaScript in a real browser environment without needing to install browsers locally.
 
+<a href="https://glama.ai/mcp/servers/@pipethedev/browsercat-mcp-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pipethedev/browsercat-mcp-server/badge" alt="BrowserCat Server MCP server" />
+</a>
+
 ## Components
 
 ### Tools


### PR DESCRIPTION
This PR adds a badge for the [BrowserCat MCP Server](https://glama.ai/mcp/servers/@pipethedev/browsercat-mcp-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@pipethedev/browsercat-mcp-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pipethedev/browsercat-mcp-server/badge" alt="BrowserCat Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.